### PR TITLE
Update create/edit note form validation

### DIFF
--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -60,7 +60,7 @@ export function App() {
             {(viewMode === ViewMode.Create || viewMode === ViewMode.Edit) &&
               <NoteForm
                 title={showItem !== null ? getNoteById(showItem).title : ''}
-                desc={showItem !== null ? getNoteById(showItem).desc : ''}
+                description={showItem !== null ? getNoteById(showItem).description : ''}
               />
             }
 
@@ -68,7 +68,7 @@ export function App() {
               <NoteShow
                 id={getNoteById(showItem).id}
                 title={getNoteById(showItem).title}
-                desc={getNoteById(showItem).desc}
+                description={getNoteById(showItem).description}
               />
             }
           </Col>

--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useEffect, useState } from 'react';
+import React, { createContext, useEffect, useMemo, useState } from 'react';
 import { Col, Container, Row } from 'react-bootstrap'
 import { getNoteList, storeNoteList } from '../../services'
 import { NoteListItemProp, ViewMode } from '../../types'
@@ -39,7 +39,7 @@ export function App() {
     }
   }, [noteList, isRender]);
 
-  const getNoteById = (id:number):NoteListItemProp => noteList.filter(item => item.id === id)[0]
+  const currentNote = useMemo(() => noteList.filter(item => item.id === showItem)[0], [showItem])
 
   return (
     <NoteContext.Provider value={{
@@ -59,16 +59,16 @@ export function App() {
 
             {(viewMode === ViewMode.Create || viewMode === ViewMode.Edit) &&
               <NoteForm
-                title={showItem !== null ? getNoteById(showItem).title : ''}
-                description={showItem !== null ? getNoteById(showItem).description : ''}
+                title={showItem !== null ? currentNote.title : ''}
+                description={showItem !== null ? currentNote.description : ''}
               />
             }
 
             {(viewMode === ViewMode.Show && showItem != null) &&
               <NoteShow
-                id={getNoteById(showItem).id}
-                title={getNoteById(showItem).title}
-                description={getNoteById(showItem).description}
+                id={currentNote.id}
+                title={currentNote.title}
+                description={currentNote.description}
               />
             }
           </Col>

--- a/src/components/note-form/note-form.tsx
+++ b/src/components/note-form/note-form.tsx
@@ -1,22 +1,21 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { Button, Form } from 'react-bootstrap'
 import ContentEditable from 'react-contenteditable'
-import { removeHTMLTags } from '../../helpers'
+import { MAX_NOTE_DESCRIPTION_LENGTH, MAX_NOTE_TITLE_LENGTH } from '../../constants'
+import { isDescriptionValid, isTitleValid, removeHTMLTags } from '../../helpers'
 import { ViewMode } from '../../types'
 import { NoteContext } from '../app'
 import styles from './note-form.module.css'
 
 export type NoteFormProp = {
   title: string;
-  desc: string;
+  description: string;
 }
 
 export function NoteForm({
   title,
-  desc
+  description
 }:NoteFormProp) {
-  const maxTitleLength = 20;
-  const maxDescLength = 1000;
   const {
     showItem,
     setShowItem,
@@ -25,35 +24,28 @@ export function NoteForm({
     noteList,
     setNoteList
   } = useContext(NoteContext);
-  const [formData, setFormData] = useState({title, desc});
-  const [isFormDataValid, setFormDataValid] = useState(false);
-  const isTitleLengthValid = ():boolean => formData.title.length <= maxTitleLength
-  const isDescLengthValid = ():boolean => formData.desc.length <= maxDescLength
+  const [formData, setFormData] = useState({title, description});
+  const isNoteTitleValid = useMemo(() => isTitleValid(formData.title), [formData.title]);
+  const isNoteDescriptionValid = useMemo(() => isDescriptionValid(formData.description), [formData.description]);
+  const noteTitleCharDifference = useMemo(() => MAX_NOTE_TITLE_LENGTH - formData.title.length, [formData.title]);
+  const noteDescriptionCharDifference = useMemo(() => MAX_NOTE_DESCRIPTION_LENGTH - formData.description.length, [formData.description]);
+  const isFormDataValid = useMemo(() => {
+    return removeHTMLTags(formData.title).length !== 0
+      && isNoteTitleValid
+      && removeHTMLTags(formData.description).length !== 0
+      && isNoteDescriptionValid
+  }, [formData])
 
   useEffect(() => {
     setFormData({
-      title: title,
-      desc: desc
+      title,
+      description
     })
-  }, [title, desc])
-
-  useEffect(() => {
-    if(removeHTMLTags(formData.title).length != 0
-      && isTitleLengthValid()
-      && removeHTMLTags(formData.desc).length != 0
-      && isDescLengthValid()
-    ) {
-      setFormDataValid(true)
-    }else{
-      setFormDataValid(false)
-    }
-  }, [formData])
-
-
+  }, [title, description])
 
   function onCreate(){
     setNoteList([...noteList, {id: new Date().getTime(), ...formData}])
-    setFormData({title: '', desc: ''})
+    setFormData({title: '', description: ''})
   }
 
   function onEdit(){
@@ -63,7 +55,7 @@ export function NoteForm({
       ) => (item.id === showItem) ? {
         ...item,
         title: formData.title,
-        desc: formData.desc
+        desc: formData.description
       } : item));
       setViewMode(ViewMode.Show);
     }
@@ -104,7 +96,7 @@ export function NoteForm({
             })}
           />
           <Form.Text className={'text-danger'}>
-            {!isTitleLengthValid() && `Field length: ${maxTitleLength - formData.title.length}`}
+            {!isNoteTitleValid && `Field length: ${noteTitleCharDifference}`}
           </Form.Text>
         </Form.Group>
 
@@ -112,28 +104,28 @@ export function NoteForm({
           <Form.Label>Content <span className="text-danger">*</span></Form.Label>
           <ContentEditable
             className={`form-control ${styles.content}`}
-            html={formData.desc}
+            html={formData.description}
             onChange={(e) => setFormData({
               ...formData,
-              desc: e.target.value
+              description: e.target.value
             })}
             style={{
               minHeight: '150px'
             }}
           />
           <Form.Text className={'text-danger'}>
-            {!isDescLengthValid() && `Field length: ${maxDescLength - formData.desc.length}`}
+            {!isNoteDescriptionValid && `Field length: ${noteDescriptionCharDifference}`}
           </Form.Text>
         </Form.Group>
 
-        {(viewMode === ViewMode.Create && <Button disabled={!isFormDataValid} onClick={() => onCreate()}>Create</Button>)}
+        {(viewMode === ViewMode.Create && <Button disabled={!isFormDataValid} onClick={onCreate}>Create</Button>)}
 
-        {(viewMode === ViewMode.Edit && <Button disabled={!isFormDataValid} onClick={() => onEdit()}>Save</Button>)}
+        {(viewMode === ViewMode.Edit && <Button disabled={!isFormDataValid} onClick={onEdit}>Save</Button>)}
 
         <Button
           variant={'outline-primary'}
           className={'mx-3'}
-          onClick={() => onCancel()}
+          onClick={onCancel}
         >
           Cancel
         </Button>

--- a/src/components/note-list-item/note-list-item.tsx
+++ b/src/components/note-list-item/note-list-item.tsx
@@ -14,7 +14,7 @@ interface Prop extends NoteListItemProp{
 export function NoteListItem({
   id,
   title,
-  desc,
+  description,
   onDelete,
   onShow,
   onEdit,
@@ -35,7 +35,7 @@ export function NoteListItem({
         <div
           style={NowrapText}
           dangerouslySetInnerHTML={{
-          __html: sanitizeHtml(desc, {
+          __html: sanitizeHtml(description, {
             allowedTags: [],
           })
         }} />

--- a/src/components/note-list/note-list.tsx
+++ b/src/components/note-list/note-list.tsx
@@ -42,7 +42,7 @@ export function NoteList() {
       noteList.filter((item) =>
         {
           return item.title.toLowerCase().includes(query)
-            || item.desc.toLowerCase().includes(query)
+            || item.description.toLowerCase().includes(query)
         }
       )
     );
@@ -75,7 +75,7 @@ export function NoteList() {
           key={noteItem.id}
           id={noteItem.id}
           title={noteItem.title}
-          desc={noteItem.desc}
+          description={noteItem.description}
           onDelete={onDelete}
           onShow={onShow}
           onEdit={onEdit}

--- a/src/components/note-show/note-show.tsx
+++ b/src/components/note-show/note-show.tsx
@@ -6,7 +6,7 @@ import styles from './note-show.module.css'
 
 export function NoteShow({
   title,
-  desc
+  description
 }:NoteListItemProp) {
   useEffect(() => {
     const links:NodeListOf<HTMLAnchorElement> = (document.querySelectorAll('a'));
@@ -32,13 +32,13 @@ export function NoteShow({
         })
       })
     }
-  }, [title, desc])
+  }, [title, description])
   return (
     <>
       <h2 className={'mb-4'}>{title}</h2>
 
       <div className={styles.content} dangerouslySetInnerHTML={{
-        __html: sanitizeHtml(desc, sanitizeConfig)
+        __html: sanitizeHtml(description, sanitizeConfig)
       }} />
     </>
   );

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './notes'

--- a/src/constants/notes.ts
+++ b/src/constants/notes.ts
@@ -1,0 +1,2 @@
+export const MAX_NOTE_TITLE_LENGTH = 20;
+export const MAX_NOTE_DESCRIPTION_LENGTH = 1000;

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,2 +1,3 @@
 export * from './sanitizeConfig'
 export * from './removeHTMLTags'
+export * from './textValidations'

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,1 +1,2 @@
 export * from './sanitizeConfig'
+export * from './removeHTMLTags'

--- a/src/helpers/removeHTMLTags.ts
+++ b/src/helpers/removeHTMLTags.ts
@@ -1,0 +1,1 @@
+export const removeHTMLTags = (text:string) => text.replace(/<[^>]+>/g, '')

--- a/src/helpers/textValidations.ts
+++ b/src/helpers/textValidations.ts
@@ -1,0 +1,4 @@
+import { MAX_NOTE_DESCRIPTION_LENGTH, MAX_NOTE_TITLE_LENGTH } from '../constants'
+
+export const isTitleValid = (title:string):boolean => title.length <= MAX_NOTE_TITLE_LENGTH
+export const isDescriptionValid = (description:string):boolean => description.length <= MAX_NOTE_DESCRIPTION_LENGTH

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,7 +1,7 @@
 export interface NoteListItemProp {
   id: number,
   title: string;
-  desc: string;
+  description: string;
 }
 
 export enum ViewMode {


### PR DESCRIPTION
- What?
Added validation for the note creation and editing form. During user input, we check for the required fields to be filled in, and also check their length. Thus, we exclude the possibility of creating an empty note or a note with a violation of the validation rules.

- How?
1. Added a method (helper) that clears a string from HTML tags.
2. Added a method to check the text length of the content field. Having previously cleared the text from tags, using the method described above.
3. Created a variable "isFormDataValid" which blocks the submit button.
4. Added a use effect method that triggers on any changes in the form, validating all required fields. And through the condition changes the value of the variable "isFormDataValid": if the validation was successful, set the value to true, and if not set false. 

- Why?
I decided to clean the content from tags to check the length so that the user can visually understand what affects the displayed value in the counter.